### PR TITLE
Switch to docker compose from docker-compose commands

### DIFF
--- a/linux-launcher/down.sh
+++ b/linux-launcher/down.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-docker-compose -f ../docker-compose.yml down
+docker compose -f ../docker-compose.yml down

--- a/linux-launcher/restart.sh
+++ b/linux-launcher/restart.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-docker-compose -f ../docker-compose.yml restart
+docker compose -f ../docker-compose.yml restart

--- a/linux-launcher/setup.sh
+++ b/linux-launcher/setup.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-docker-compose -f ../docker-compose.yml up -d
+docker compose -f ../docker-compose.yml up -d

--- a/linux-launcher/start.sh
+++ b/linux-launcher/start.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-docker-compose -f ../docker-compose.yml start
+docker compose -f ../docker-compose.yml start

--- a/linux-launcher/stop.sh
+++ b/linux-launcher/stop.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-docker-compose -f ../docker-compose.yml stop
+docker compose -f ../docker-compose.yml stop

--- a/linux-launcher/update.sh
+++ b/linux-launcher/update.sh
@@ -1,3 +1,3 @@
 #! /bin/bash
-docker-compose -f ../docker-compose.yml pull
-docker-compose -f ../docker-compose.yml up -d
+docker compose -f ../docker-compose.yml pull
+docker compose -f ../docker-compose.yml up -d


### PR DESCRIPTION
Replaced deprecated docker-compose commands with docker compose in all scripts within the linux-launcher directory for better compatibility and alignment with newer Docker CLI standards. This ensures future-proofing and avoids potential issues with outdated tooling. Note: docker compose is the new syntax supported by recent versions of Docker (v20.10.13 and above), so make sure you're using a compatible Docker version.